### PR TITLE
feat(properties): implementando funcionalidade de seleção de propriedades

### DIFF
--- a/src/config/regex.js
+++ b/src/config/regex.js
@@ -1,3 +1,3 @@
-export const MONSTER_NAME_REGEX = /(?<!!)(?<!\w)\w+/g;
-
+export const MONSTER_NAME_REGEX = /(?<![\w\!\[\];])(\w+)(?![\w\s;]*\])/g;
 export const OPTIONS_REGEX = /(?<=!)\w+/g;
+export const MONSTER_PROPERTIES_REGEX = /(?<=!properties\s\[|;)[^;\]]+/g;

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { getMonster, getAvailableMonsters } from "./libs/monsters";
 import {
   getParamsFromCommand,
   createOptionsList,
+  getSelectedProperties
 } from "./libs/messages/messagesUtil";
 
 import {
@@ -29,10 +30,12 @@ client.on("message", async (message) => {
     const availableMonsters = availableMonstersRequest && availableMonstersRequest.results.map((monster) => monster.name);
 
     if (availableMonsters) {
+      const properties = getSelectedProperties(message.content);
+
       if (availableMonsters.length === 1) {
         const selectedMonster = await getMonster(availableMonsters[0]);
 
-        const responseMessage = formatMonsterDataIntoMessage(selectedMonster);
+        const responseMessage = formatMonsterDataIntoMessage(selectedMonster, properties);
         channel.send(responseMessage);
       } else if (availableMonsters.length > 1) {
         const responseMessage = createOptionsList(availableMonsters);
@@ -58,7 +61,7 @@ client.on("message", async (message) => {
               availableMonsters
             )
               .then((monster) => {
-                const monsterDataMessage = formatMonsterDataIntoMessage(monster);
+                const monsterDataMessage = formatMonsterDataIntoMessage(monster, properties);
 
                 channel.send(monsterDataMessage);
               })

--- a/src/libs/messages/messagesUtil.js
+++ b/src/libs/messages/messagesUtil.js
@@ -1,6 +1,6 @@
 import { MessageEmbed } from "discord.js";
 
-import { MONSTER_NAME_REGEX, OPTIONS_REGEX } from "../../config/regex";
+import { MONSTER_NAME_REGEX, OPTIONS_REGEX, MONSTER_PROPERTIES_REGEX } from "../../config/regex";
 
 export const getParamsFromCommand = (messageContent) => {
   const normalizedMonsterName = messageContent
@@ -36,3 +36,8 @@ export const createOptionsList = (options) => {
   }
 };
 
+export const getSelectedProperties = (message) => {
+  const properties = message.match(MONSTER_PROPERTIES_REGEX) || [];
+
+  return properties.map(prop => prop.trim().replace(" ", "_").toLowerCase());
+}

--- a/src/libs/messages/monsterMessages.js
+++ b/src/libs/messages/monsterMessages.js
@@ -8,21 +8,27 @@ import { getMonster } from "../monsters";
 import { singleLineProperties } from "../../config/botConfig";
 import { BASE_MORE_INFO_URL } from "../../config/generalConfig";
 
-export const formatMonsterDataIntoMessage = (monster) => {
-  const formatedMessage = new MessageEmbed();
-
+export const formatMonsterDataIntoMessage = (monster, selectedProperties = []) => {
   const { name, slug, ...monsterInfo } = monster;
 
-  formatedMessage
-    .setTitle(name)
-    .setColor(getRandomColor())
-    .setURL(`${BASE_MORE_INFO_URL}${slug}`);
+  const formatedMessage = new MessageEmbed({
+    title: name,
+    color: getRandomColor(),
+    url: `${BASE_MORE_INFO_URL}${slug}`,
+  });
+
+  const monsterInfoEntries = Object.entries(monsterInfo);
+  const hasValidSelectedProperties = monsterInfoEntries.some(([key]) => selectedProperties.indexOf(key) >= 0);
 
   for (let [key, value] of Object.entries(monsterInfo)) {
     const [normalizedField, normalizedValue] = normalizeKeyValuePair(
       key,
       value
     );
+
+    if (hasValidSelectedProperties && (selectedProperties.indexOf(key) < 0)) {
+      continue;
+    }
 
     const shouldValueBeInline = !singleLineProperties.includes(key);
 


### PR DESCRIPTION
## `!luck monsterName !properties [prop1;prop2;prop3]`

• `!properties [prop1;prop2;prop3]` pode ser colocado em qualquer posição no comando do bot
• Propriedades que possuem espaço podem ser passadas com o espaço sem problemas, permite também uppercase
• Busca somente pelas propriedades válidas, caso nenhuma seja será mostrada todas as informações do monstro

https://github.com/SirPedr/LuckTheDuck/issues/7